### PR TITLE
只在处理相关命令时产生输出

### DIFF
--- a/StartStopHelper.py
+++ b/StartStopHelper.py
@@ -11,26 +11,39 @@ def wait(server, command, time_wait):
 		time_wait -= 1
 
 
+CMD_PREFIX = '!!'
+RECOGNIZED_CMDS = [
+	'start',
+	'stop',
+	'stop_exit',
+	'restart'
+]
+
+
 def on_info(server, info):
 	if info.is_user:
+		args = info.content.split(' ')
+		if len(args) not in [1, 2] or not args[0].startswith(CMD_PREFIX):
+			return
+
+		command = args[0][len(CMD_PREFIX):]
+		if command not in RECOGNIZED_CMDS:
+			return
+
 		if server.get_permission_level(info) >= 3:  # admin
-			args = info.content.split(' ')
-			if len(args) not in [1, 2]:
-				return
 			if len(args) == 2 and not args[1].isdigit():
 				server.reply(info, '[<time_wait>] argument need to be a number')
 				return
-			command = args[0]
 			time_wait = int(args[1]) if len(args) == 2 else 10
-			if command == '!!start':
+			if command == 'start':
 				server.start()
-			elif command == '!!stop':
+			elif command == 'stop':
 				wait(server, 'stop', time_wait)
 				server.stop()
-			elif command == '!!stop_exit':
+			elif command == 'stop_exit':
 				wait(server, 'stop', time_wait)
 				server.stop_exit()
-			elif command == '!!restart':
+			elif command == 'restart':
 				wait(server, 'restart', time_wait)
 				server.restart()
 		else:


### PR DESCRIPTION
原先只要 admin 说的话有空格就会认为 time wait 格式不对，而其他玩家说话就会 Permission denied。现在先过滤掉不相关的聊天。